### PR TITLE
check-branches: Automatically fill in Config.host_owner

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 0.8.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Automatically detect the appropriate ``host_owner`` if undefined, in
+  ``check-branches``.
+- |backward-incompatible| **check-branches**: Drop ``host_owner`` option in the configuration file. You should remove
+  this option, otherwise an error will occur while reading the configuration file.
 
 
 0.8.3 (2020-10-27)
@@ -37,3 +40,9 @@ First public release.
 ------------------
 
 First apparition in a private tool.
+
+
+.. role:: raw-html(raw)
+.. |backward-incompatible| raw:: html
+
+    <span style="background-color: #ffffbc; padding: 0.3em; font-weight: bold;">backward incompatible</span>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+global-exclude *.py[cod]
+
 include CHANGES.rst
 include LICENSE.txt
 include README.rst

--- a/docs/check_branches.rst
+++ b/docs/check_branches.rst
@@ -165,7 +165,6 @@ It looks like this:
 
     host-api-access.platform = 'github'
     host-api-access.auth-token-file = '~/.config/github_auth_token'
-    host-owner = 'Polyconseil'
 
 See below for the possible keys in this table. Currently, only GitHub
 is supported.
@@ -227,22 +226,12 @@ API client to use. For now, only ``github`` is supported.
 | Example: ``host-api-access.platform = "github"``.
 
 
-``host-owner``
-..............
-
-The owner of the repository. The value is injected into ``host-url``
-below to build the URL of each branch of the repository.
-
-| Type: string.
-| Default: ``None``.
-| Example: ``host-owner = "YourCompany"``.
-
-
 ``host-url``
 ............
 
 The pattern to be used to build the URL of each branch of the
-repository. The default value is tailored for GitHub.
+repository. The default value is tailored for GitHub. The ``{owner}``
+value is extracted from the remote origin's URL.
 
 | Type: string.
 | Default: ``"https://github.com/{owner}/{repo}/tree/{branch}"``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,6 @@ whitelist = [
 ]
 
 
-[tool.check-branches]
-host-owner = 'Polyconseil'
-
-
 [tool.isort]
 multi_line_output = 3
 use_parentheses = true

--- a/tests/test_check_branches.py
+++ b/tests/test_check_branches.py
@@ -29,6 +29,25 @@ def intercept_commands(replacements):
         yield
 
 
+def test_get_repository_info():
+    valid_urls = [
+        'https://github.com/TestOrg/project_name',
+        'git@github.com:TestOrg/project_name',
+        'git@github.com:TestOrg/project_name.git',
+    ]
+
+    for url in valid_urls:
+        with mock.patch('check_oldies.commands.get_output', return_value=[url]):
+            owner, repo_name = branches.get_repository_info('.')
+        assert owner == 'TestOrg', url
+        assert repo_name == 'project_name', url
+
+    # Unsupported format
+    with mock.patch('check_oldies.commands.get_output', return_value=['ftp://github.com/TestOrg/project_name']):
+        with pytest.raises(ValueError):
+            owner, repo_name = branches.get_repository_info('.')
+
+
 def test_output_fresh_branches(capfd):  # capfd is a pytest fixture
     config = branches.Config(
         path=base.TEST_DIR_PATH.parent,
@@ -50,9 +69,11 @@ def test_output_fresh_branches(capfd):  # capfd is a pytest fixture
 
 
 def test_output_old_branches(capfd):  # capfd is a pytest fixture
+    with pytest.raises(TypeError):
+        config = branches.Config(host_owner='Polyconseil')
+
     config = branches.Config(
         path=base.TEST_DIR_PATH.parent,
-        host_owner="Polyconseil",
         colorize_errors=False,
     )
 


### PR DESCRIPTION
I think it's an easy change that allows to automatically detect the `owner` required to build URLs, instead of building
URLs containing `None` in the path if left undefined.
