### PR TITLE
annotations: introduce new ignore_orphans_annotations option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.8.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ``ignore_orphans_annotations`` config option.
+This option ignore orphan future tags check on ignored annotations.
 
 
 0.8.4 (2020-11-18)

--- a/docs/check_fixmes.rst
+++ b/docs/check_fixmes.rst
@@ -301,6 +301,18 @@ The extended regular expression to use to detect FUTURE tags.
 | Default: ``"FUTURE-[-[:alnum:]\._]+?"``.
 | Example: ``future-tag-regex = "HEREAFTER-[-[:alnum:]\._]+?"``.
 
+.. _conf_ignored_orphans_annotations:
+
+``ignored_orphans_annotations``
+...............
+
+The list of annotations which will not trigger orphan FUTURE tags checks.
+Note that **check-fixmes** is case insensitive:
+by default, both "wontfix", "WONTFIX" will be ignored.
+
+| Type: list.
+| Default: ``["wontfix", "xxx"]`` (case insensitive).
+| Example: ``ignored_annotations = ["wontfix", "nofix"]``.
 
 .. _conf_max_age:
 

--- a/src/check_oldies/annotations.py
+++ b/src/check_oldies/annotations.py
@@ -23,7 +23,8 @@ class Config:
     colorize_errors: bool = True
     xunit_file: str = None
 
-    annotations: typing.Sequence = ("todo", "fixme")  # no-check-fixmes
+    annotations: typing.Sequence = ("todo", "fixme", )  # no-check-fixmes
+    ignored_orphans_annotations: typing.Sequence = ("wontfix", "xxx")  # annotation which won't trigger orphans checks
     assignee_regex: str = r"(?:{annotation_regex})\s*\((?P<assignee>[\w\._-]+)"
     future_tag_regex: str = r"FUTURE-[-[:alnum:]\._]+?"  # no-check-fixmes
 
@@ -32,6 +33,10 @@ class Config:
     @property
     def annotation_regex(self):
         return "|".join(self.annotations).lower()
+
+    @property
+    def ignored_orphans_annotations_regex(self):
+        return "|".join(self.ignored_orphans_annotations).lower()
 
     @property
     def _annotation_with_boundaries_regex(self):
@@ -261,7 +266,9 @@ def get_orphan_futures(config):
     line with an annotation.
     """
     known_tags = get_known_future_tags(
-        config.path, config.annotation_regex, config.future_tag_regex, config.whitelist,
+        config.path,
+        fr'{config.ignored_orphans_annotations_regex}|{config.annotation_regex}',
+        config.future_tag_regex, config.whitelist,
     )
     futures = get_all_futures(config.path, config.future_tag_regex, config.whitelist)
     orphans = []

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,7 +10,7 @@ TEST_DIR_PATH = pathlib.Path(os.path.dirname(__file__))
 # tests.
 TESTING_ANNOTATIONS = ["TIMEBOMB"]
 TESTING_FUTURE_TAG = r"FEWTURE-[-[:alnum:]\._]+?"
-
+TESTING_IGNORED_ORPHANS_ANNOTATIONS = ["NOFIX"]
 
 # We need to force the age of each line (i.e. the datetime of the
 # latest commit that touched each line) that we want to display,

--- a/tests/data/project6/file1.py
+++ b/tests/data/project6/file1.py
@@ -1,0 +1,2 @@
+# TIMEBOMB - FEWTURE-BOOM: report me
+# NOFIX - FEWTURE-NOBOOM: do not report me

--- a/tests/data/project6/file2.py
+++ b/tests/data/project6/file2.py
@@ -1,0 +1,4 @@
+# FEWTURE-BOOM: do not report me (not an orphan)
+# FEWTURE-NOBOOM: do not report me (not an orphan)
+# FEWTURE-I-AM-AN-ORPHAN: report me
+# FEWTURE-I-AM-NOT-AN-ORPHAN: do not report me (pragma)  no-check-fixmes

--- a/tests/test_check_fixmes.py
+++ b/tests/test_check_fixmes.py
@@ -56,6 +56,31 @@ def test_output_when_no_annotations(capfd):  # capfd is a pytest fixture
 
 
 @mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
+def test_output_with_ignored_annotations_orphans_future_tags(capfd):  # capfd is a pytest fixture
+    config = annotations.Config(
+        path=base.TEST_DIR_PATH / "data/project6",
+        colorize_errors=False,
+        annotations=base.TESTING_ANNOTATIONS,
+        ignored_orphans_annotations=base.TESTING_IGNORED_ORPHANS_ANNOTATIONS,
+        future_tag_regex=base.TESTING_FUTURE_TAG,
+    )
+
+    with mock.patch("check_oldies.configuration.get_config", return_value=config):
+        with pytest.raises(SystemExit) as caught_exit:
+            check_fixmes.main()
+    captured = capfd.readouterr()
+
+    assert caught_exit.value.code == 65
+    stdout = captured.out.rstrip().split(os.linesep)
+    expected = [
+        'NOK: Some annotations are too old, or there are orphan FUTURE tags.',
+        'jane.doe        -    2 days - file1.py:1: # TIMEBOMB - FEWTURE-BOOM: report me',
+        'jane.doe        -   ORPHAN  - file2.py:3: Unknown tag FEWTURE-I-AM-AN-ORPHAN'
+    ]
+    assert stdout == expected
+
+
+@mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
 def test_output_with_orphan_future_tags(capfd):  # capfd is a pytest fixture
     config = annotations.Config(
         path=base.TEST_DIR_PATH / "data/project3",


### PR DESCRIPTION
This option has the purpose of not triggering the orphans future tags checks on the list of ignore_orphans_annotations.

It can be helpful to keep track of associated future tags even on skipped annotations.

For example:
    If a skipped annotation "WONTFIX" in our case and is specified in ignore_orphans_annotations options, the following lines will not appear in the error list
```
    file1.py : `#WONTFIX (FUTURE-DROP-MODIFICATION)`
    file2.py :  FUTURE-DROP-MODIFICATION: This modification should be drop after api is deprecated
```