### PR TITLE
feat: Separate FUTURE flags detection in `check-future-flags` command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,9 @@
-0.8.11 (unreleased)
--------------------
+1.0.0 (unreleased)
+------------------
 
-- Nothing changed yet.
+- |backward-incompatible| A new **check-future-tags** command is
+  introduced that reports orphan future tags. **check-fixmes** does
+  **not** report those tags anymore, it only reports outdated FIXME's.
 
 
 0.8.10 (2023-08-16)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ quality:
 	pylint --reports=no setup.py src/check_oldies tests
 	check-branches
 	check-fixmes
+	check-future-tags
 	python setup.py sdist >/dev/null 2>&1 && twine check dist/*
 
 .PHONY: clean

--- a/docs/check_fixmes.rst
+++ b/docs/check_fixmes.rst
@@ -5,17 +5,11 @@ check-fixmes
 Features and usage
 ==================
 
-There are two main features:
+This command detects old annotations: FIXME, TODO, etc.
 
-- detection of old annotations (FIXME, TODO, etc.);
-- detection of forgotten FUTURE tags.
-
-
-Detection of old annotations
-----------------------------
 
 Rationale and principles
-........................
+------------------------
 
 Developers use annotations to indicate that some code is deficient:
 FIXME, TODO, OPTIMIZE, HACK, BUG, etc. Semantics vary, but the overall
@@ -46,7 +40,7 @@ used.
 
 
 Usage and possible customization
-................................
+--------------------------------
 
 .. code-block:: console
 
@@ -96,64 +90,19 @@ be an annotation, but not in this context. For example, in a CSS file:
     }
 
 If you need to ignore whole files, see the :ref:`whitelist option
-<conf_whitelist>`.
+<check_fixmes_conf_whitelist>`.
 
 Possible customizations:
 
 - which type of annotations are taken in account (FIXME, TODO,
   OPTIMIZE, etc.): see the :ref:`annotations option
-  <conf_annotations>`;
+  <check_fixmes_conf_annotations>`;
 
 - how assignments are formatted: see the the :ref:`assignee_regex
-  option <conf_assignee_regex>`;
+  option <check_fixmes_conf_assignee_regex>`;
 
 - the age above which an annotation is considered old: see the
-  :ref:`max-age option <conf_max_age>`;
-
-See the :ref:`check_fixmes_configuration` section below for full details.
-
-
-Detection of orphan FUTURE tags
--------------------------------
-
-Rationale and principles
-........................
-
-Developers sometimes plan a broad modification that will span multiple
-files. Instead of littering FIXME annotations everywhere, they can set
-a single FIXME annotation and a FUTURE-xxx tag on the same line. Then,
-wherever we need to make a modification, we only mention this
-FUTURE-xxx tag without any FIXME. If we have to "postpone" a FIXME,
-there is only line to touch.
-
-Example:
-
-.. code-block:: text
-
-    # in file1.py:
-    #
-    #     FIXME (jsmith, FUTURE-SWITCH-TO-V2): remove this field when we switch to v2
-    #
-    # in file2.py:
-    #
-    #     FUTURE-SWITCH-TO-V2: deprecate usage when we switch to v2
-
-If we ever remove the FIXME but keep the FUTURE-SWITCH-TO-V2 tag in
-``file2.py``, it is a mistake and **check-fixmes** warns us.
-
-
-Usage and possible customization
-................................
-
-**check-fixmes** looks for tags that start with ``FUTURE-``
-(e.g. ``FUTURE-SWITCH-TO-V2``) to make sure that at least one of them
-appears on the same line as an annotation. If not, it is considered an
-orphan tag and is reported as an error.
-
-As for annotations, you can ignore a line by using
-``no-check-fixmes``, and ignore whole files with the :ref:`whitelist
-option <conf_whitelist>`. You can configure how tags are detected with
-the :ref:`future_tag_regex option <conf_future_tag_regex>`.
+  :ref:`max-age option <check_fixmes_conf_max_age>`;
 
 See the :ref:`check_fixmes_configuration` section below for full details.
 
@@ -195,7 +144,7 @@ configuration file:
 Input options
 -------------
 
-.. _conf_path:
+.. _check_fixmes_conf_path:
 
 ``path`` (overridable via the command line)
 ...........................................
@@ -208,7 +157,7 @@ annotations (recursively). It must be a Git checkout repository.
 | Example: ``path = "src"``.
 
 
-.. _conf_whitelist:
+.. _check_fixmes_conf_whitelist:
 
 ``whitelist``
 .............
@@ -224,7 +173,7 @@ whitelist whole files by providing a list of glob patterns.
 Output options
 --------------
 
-.. _conf_colorize_errors:
+.. _check_fixmes_conf_colorize_errors:
 
 ``colorize-errors``
 ...................
@@ -238,7 +187,7 @@ default foreground color.
 | Example: ``colorize-errors = false``.
 
 
-.. _conf_xunit_file:
+.. _check_fixmes_conf_xunit_file:
 
 ``xunit-file`` (overridable via the command line)
 .................................................
@@ -255,7 +204,7 @@ exist.
 Detection options
 -----------------
 
-.. _conf_annotations:
+.. _check_fixmes_conf_annotations:
 
 ``annotations``
 ...............
@@ -269,7 +218,7 @@ case insensitive: by default, both "todo", "TODO", "fixme" and
 | Example: ``annotations = ["todo", "optimize", "fixme", "hack"]``.
 
 
-.. _conf_assignee_regex:
+.. _check_fixmes_conf_assignee_regex:
 
 ``assignee-regex``
 ..................
@@ -290,31 +239,7 @@ assignee in an annotation. Requirements:
 .. _Python syntax: https://docs.python.org/3/library/re.html#regular-expression-syntax
 
 
-.. _conf_future_tag_regex:
-
-``future-tag-regex``
-....................
-
-The extended regular expression to use to detect FUTURE tags.
-
-| Type: string (an extended regular expression).
-| Default: ``"FUTURE-[-[:alnum:]\._]+?"``.
-| Example: ``future-tag-regex = "HEREAFTER-[-[:alnum:]\._]+?"``.
-
-.. _conf_ignored_orphans_annotations:
-
-``ignored_orphans_annotations``
-...............................
-
-The list of annotations which will not trigger orphan FUTURE tags checks.
-Note that **check-fixmes** is case insensitive:
-by default, both "wontfix", "WONTFIX" will be ignored.
-
-| Type: list.
-| Default: ``["wontfix", "xxx"]`` (case insensitive).
-| Example: ``ignored_annotations = ["wontfix", "nofix"]``.
-
-.. _conf_max_age:
+.. _check_fixmes_conf_max_age:
 
 ``max-age`` (overridable via the command line)
 ..............................................

--- a/docs/check_future_tags.rst
+++ b/docs/check_future_tags.rst
@@ -1,0 +1,186 @@
+=================
+check-future-tags
+=================
+
+Features and usage
+==================
+
+This command detects orphan "FUTURE" tags.
+
+
+Rationale and principles
+------------------------
+
+Developers sometimes plan broad modifications that will span multiple
+files. Instead of littering FIXME annotations everywhere, they can set
+a single FIXME annotation and a FUTURE-xxx tag on the same line. Then,
+wherever we need to make a modification, we only mention this
+FUTURE-xxx tag without any FIXME. If we have to "postpone" a FIXME,
+there is only line to touch.
+
+Example:
+
+.. code-block:: text
+
+    # in file1.py:
+    #
+    #     FIXME (jsmith, FUTURE-SWITCH-TO-V2): remove this field when we switch to v2
+    #
+    # in file2.py:
+    #
+    #     FUTURE-SWITCH-TO-V2: deprecate usage when we switch to v2
+
+If we ever remove the FIXME but keep the FUTURE-SWITCH-TO-V2 tag in
+``file2.py``, it is a mistake and **check-future-tags** warns us.
+
+
+Usage and possible customization
+--------------------------------
+
+**check-future-tags** looks for tags that start with ``FUTURE-``
+(e.g. ``FUTURE-SWITCH-TO-V2``) to make sure that at least one of them
+appears on the same line as an annotation. If not, it is considered an
+orphan tag and is reported as an error.
+
+As for annotations, you can ignore a line by using
+``no-check-fixmes``, and ignore whole files with the :ref:`whitelist
+option <check_future_tags_conf_whitelist>`. You can configure how tags are detected with
+the :ref:`future_tag_regex option <check_future_tags_conf_future_tag_regex>`.
+
+See the :ref:`check_future_tags_configuration` section below for full details.
+
+
+.. _check_future_tags_configuration:
+
+Configuration
+=============
+
+**check-future-tags** takes its configuration from a TOML file. By
+default and if present, ``pyproject.toml`` is read (as a courtesy for
+Python projects, even though **check-future-tags** is
+language-agnostic). A limited list of options can be overridden via
+command line arguments (that you can list with ``check-future-tags
+--help``). Such overrides take precedence over the values defined in
+the configuration files (or the default values if omitted).
+
+The TOML configuration file should have a ``[tool.check-future-tags]``
+section, like this:
+
+.. code-block:: toml
+
+    [tool.check-future-tags]
+    path = "src"
+    max-age = 30
+
+For an example configuration file, see `the configuration file
+<https://github.com/Polyconseil/check-oldies/blob/master/pyproject.toml#L1-L14>`_
+of the **check-future-tags** project itself.
+
+Here is the list of all options that can be configured via the TOML
+configuration file:
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Input options
+-------------
+
+.. _check_future_tags_conf_path:
+
+``path`` (overridable via the command line)
+...........................................
+
+The path of the directory in which **check-future-tags** looks for
+annotations (recursively). It must be a Git checkout repository.
+
+| Type: string.
+| Default: ``"."`` (current working directory).
+| Example: ``path = "src"``.
+
+
+.. _check_future_tags_conf_whitelist:
+
+``whitelist``
+.............
+
+If the ``no-check-fixmes`` pragma is not appropriate, you may
+whitelist whole files by providing a list of glob patterns.
+
+| Type: list.
+| Default: ``[]`` (no whitelist).
+| Example: ``whitelist = ["docs/*"]``.
+
+
+Output options
+--------------
+
+.. _check_future_tags_conf_colorize_errors:
+
+``colorize-errors``
+...................
+
+By default, errors (old annotations and orphan FUTURE tags) appear
+in red. Set this option to ``false`` if you want to use the
+default foreground color.
+
+| Type: boolean.
+| Default: ``true``.
+| Example: ``colorize-errors = false``.
+
+
+.. _check_future_tags_conf_xunit_file:
+
+``xunit-file`` (overridable via the command line)
+.................................................
+
+The path to the xUnit report file to generate. **check-future-tags**
+gracefully creates parent directories of the file if they do not
+exist.
+
+| Type: string (a path).
+| Default: none (no xUnit file is generated).
+| Example: ``xunit-file = "reports/xunit.xml"``.
+
+
+Detection options
+-----------------
+
+.. _check_future_tags_conf_annotations:
+
+``annotations``
+...............
+
+The list of annotations to look for. Note that **check-future-tags** is
+case insensitive: by default, both "todo", "TODO", "fixme" and
+"FIXME" will be reported.
+
+| Type: list.
+| Default: ``["fixme", "todo"]`` (case insensitive).
+| Example: ``annotations = ["todo", "optimize", "fixme", "hack"]``.
+
+
+.. _check_future_tags_conf_future_tag_regex:
+
+``future-tag-regex``
+....................
+
+The extended regular expression to use to detect FUTURE tags.
+
+| Type: string (an extended regular expression).
+| Default: ``"FUTURE-[-[:alnum:]\._]+?"``.
+| Example: ``future-tag-regex = "HEREAFTER-[-[:alnum:]\._]+?"``.
+
+.. _check_future_tags_conf_ignored_orphans_annotations:
+
+``ignored_orphans_annotations``
+...............................
+
+The list of annotations which will not trigger orphan FUTURE tags
+checks.  Note that **check-future-tags** is case insensitive: by
+default, both "wontfix", "WONTFIX" will be ignored.
+
+| Type: list.
+| Default: ``["wontfix", "xxx"]`` (case insensitive).
+| Example: ``ignored_orphans_annotations = ["wontfix", "nofix"]``.

--- a/docs/forget_me_not.rst
+++ b/docs/forget_me_not.rst
@@ -6,10 +6,10 @@ forget-me-not
 Rationale
 =========
 
-**check-fixmes** and **check-branches** can be run as part of the test
-suite of each project (by a continuous integration system such as
-Jenkins). They break builds when they detect old annotations or
-branches.
+**check-branches**, **check-fixmes** and **check-future-tags** can be
+run as part of the test suite of each project (by a continuous
+integration system such as Jenkins). They break builds when they
+detect old annotations or branches.
 
 But nobody wants to see builds break unexpectedly. What if you were
 warned that a build *will soon* break because of an old annotation or
@@ -47,8 +47,8 @@ details.
 To detect old annotations and branches, **forget-me-not** uses the
 configuration files **of each project** (or defaults for project that
 do not have configuration files). See previous chapters for further
-details about the configuration of **check-fixmes** and
-**check-branches**.
+details about the configuration of **check-branches**,
+**check-fixmes** and **check-future-tags**.
 
 
 .. _forget_me_not_configuration:
@@ -254,7 +254,7 @@ The user to use when contacting the SMTP host to send e-mail reports.
 | Example: ``smtp.user = "USERNAME"``.
 
 ``smtp.password``
-.............
+.................
 
 The password to use when contacting the SMTP host to send e-mail reports.
 | Type: string.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,8 +4,7 @@ check-oldies
 **check-oldies** is a collection of programs that warn about old
 things in code:
 
-- **check-fixmes** warns about old FIXME or TODO annotations and
-  orphan FUTURE tags.
+- **check-fixmes** warns about old FIXME or TODO annotations.
 
   If we did not regularly check, we would forget about that FIXME note
   we wrote a few months ago. **check-fixmes** warns us about it. It is
@@ -13,21 +12,23 @@ things in code:
   not worth to fix, or because it is not relevant anymore), or
   postpone it.
 
-  FUTURE tags: We sometimes plan a broad modification that will span
-  multiple files. Instead of littering FIXME annotations everywhere,
-  we set a single FIXME annotation and a FUTURE-xxx tag on the same
-  line. Then, wherever we need to make a modification, we only
-  mention this FUTURE-xxx tag without any FIXME. If we ever remove the
-  FIXME but keep a FUTURE-xxx tag somewhere, it is a mistake and this
-  tool warns us.
+- **check-future-tags** warns about orphan FUTURE tags.
+
+  We sometimes plan a broad modification that will span multiple
+  files. Instead of littering FIXME annotations everywhere, we set a
+  single FIXME annotation and a FUTURE-xxxx tag on the same line
+  (e.g. "FUTURE-MIGRATION-TO-API-V3". Then, wherever we need to make a
+  modification, we only mention this FUTURE-xxxx tag without any
+  FIXME. If we ever remove the FIXME but keep a FUTURE-xxxx tag
+  somewhere, it is a mistake and this tool warns us.
 
 - **check-branches** warns about old branches, surprisingly.
 
-- **forget-me-not** runs both programs above on a set of Git
+- **forget-me-not** runs all programs above on a set of Git
   repositories and sends warning e-mails to authors of soon-to-be-old
   annotations or branches.
 
-In other words: **check-fixmes** and **check-branches** can be run as
+In other words: **check-branches**, **check-fixmes** and **check-future-tags** can be run as
 part of the test suite of each project (by a continuous integration
 system such as Jenkins). They break builds when they detect old
 things.  On the other hand, **forget-me-not** can be run once a week
@@ -51,6 +52,13 @@ Example output:
     NOK: Some branches are too old.
     john.smith@example.com     -   92 days - jsmith/fix_frobs (https://github.com/Polyconseil/check-oldies/tree/jsmith/fix_frobs), linked to open PR/MR #1 (https://github.com/Polyconseil/check-oldies/pull/1)
 
+.. code-block:: console
+
+    $ check-future-tags
+    NOK: There are orphan FUTURE tags.
+    john.smith@example.com -   ORPHAN  - src/check_oldies/check_fixmes.py:92: Unknown tag FUTURE-NEW-FORMAT-ARGUMENT
+
+
 **check-oldies** is written in Python but is language-agnostic. It
 works on Git repositories but could be extended to other version
 control systems. It integrates with GitHub and GitLab but can do without it, and
@@ -69,6 +77,7 @@ could be extended to work with other code hosting platforms.
    installation.rst
    check_fixmes.rst
    check_branches.rst
+   check_future_tags.rst
    forget_me_not.rst
    contributing.rst
    changes.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ Example output:
 
 **check-oldies** is written in Python but is language-agnostic. It
 works on Git repositories but could be extended to other version
-control systems. It integrates with GitHub but can do without it, and
+control systems. It integrates with GitHub and GitLab but can do without it, and
 could be extended to work with other code hosting platforms.
 
 **check-oldies** is written by `Polyconseil`_ and is licensed under the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,17 @@ whitelist = [
     "docs/*.rst",
 ]
 
+[tool.check-future-tags]
+path = "."
+
+annotations = [
+    "fixme",
+    "todo",
+]
+whitelist = [
+    "docs/*.rst",
+]
+
 
 [tool.isort]
 multi_line_output = 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = check-oldies
-version = 0.8.11.dev0
+version = 1.0.0.dev0
 description = Warns about unattended branches and FIXME or TODO annotations
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -37,8 +37,9 @@ packages=find:
 
 [options.entry_points]
 console-scripts =
-    check-fixmes = check_oldies.check_fixmes:main
     check-branches = check_oldies.check_branches:main
+    check-fixmes = check_oldies.check_fixmes:main
+    check-future-tags = check_oldies.check_future_tags:main
     forget-me-not = check_oldies.forget_me_not:main
 
 [options.extras_require]

--- a/tests/data/project3/file1.py
+++ b/tests/data/project3/file1.py
@@ -1,1 +1,1 @@
-# TIMEBOMB - FEWTURE-BOOM: report me
+# TIMEBOMB - FEWTURE-BOOM: report as an annotation

--- a/tests/test_check_branches.py
+++ b/tests/test_check_branches.py
@@ -51,7 +51,7 @@ def test_get_repository_info():
             host, owner, repo_name = branches.get_repository_info('.')
 
 
-def test_output_fresh_branches(capfd):  # capfd is a pytest fixture
+def test_output_fresh_branches(capfd: pytest.CaptureFixture):
     config = branches.Config(
         path=base.TEST_DIR_PATH.parent,
         max_age=9999,
@@ -71,7 +71,7 @@ def test_output_fresh_branches(capfd):  # capfd is a pytest fixture
     assert stdout[0] == "OK: All branches are fresh."
 
 
-def test_output_old_branches(capfd):  # capfd is a pytest fixture
+def test_output_old_branches(capfd: pytest.CaptureFixture):
     with pytest.raises(TypeError):
         config = branches.Config(host_owner='Polyconseil')  # pylint: disable=unexpected-keyword-arg
 

--- a/tests/test_check_fixmes.py
+++ b/tests/test_check_fixmes.py
@@ -55,54 +55,6 @@ def test_output_when_no_annotations(capfd):  # capfd is a pytest fixture
     assert stdout == expected
 
 
-@mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
-def test_output_with_ignored_annotations_orphans_future_tags(capfd):  # capfd is a pytest fixture
-    config = annotations.Config(
-        path=base.TEST_DIR_PATH / "data/project6",
-        colorize_errors=False,
-        annotations=base.TESTING_ANNOTATIONS,
-        ignored_orphans_annotations=base.TESTING_IGNORED_ORPHANS_ANNOTATIONS,
-        future_tag_regex=base.TESTING_FUTURE_TAG,
-    )
-
-    with mock.patch("check_oldies.configuration.get_config", return_value=config):
-        with pytest.raises(SystemExit) as caught_exit:
-            check_fixmes.main()
-    captured = capfd.readouterr()
-
-    assert caught_exit.value.code == 65
-    stdout = captured.out.rstrip().split(os.linesep)
-    expected = [
-        'NOK: Some annotations are too old, or there are orphan FUTURE tags.',
-        'jane.doe        -    2 days - file1.py:1: # TIMEBOMB - FEWTURE-BOOM: report me',
-        'jane.doe        -   ORPHAN  - file2.py:3: Unknown tag FEWTURE-I-AM-AN-ORPHAN'
-    ]
-    assert stdout == expected
-
-
-@mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
-def test_output_with_orphan_future_tags(capfd):  # capfd is a pytest fixture
-    config = annotations.Config(
-        path=base.TEST_DIR_PATH / "data/project3",
-        colorize_errors=False,
-        annotations=base.TESTING_ANNOTATIONS,
-        future_tag_regex=base.TESTING_FUTURE_TAG,
-    )
-
-    with mock.patch("check_oldies.configuration.get_config", return_value=config):
-        with pytest.raises(SystemExit) as caught_exit:
-            check_fixmes.main()
-    captured = capfd.readouterr()
-
-    assert caught_exit.value.code == 65
-    stdout = captured.out.rstrip().split(os.linesep)
-    expected = [
-        "NOK: Some annotations are too old, or there are orphan FUTURE tags.",
-        "jane.doe        -    2 days - file1.py:1: # TIMEBOMB - FEWTURE-BOOM: report me",
-        "jane.doe        -   ORPHAN  - file2.py:2: Unknown tag FEWTURE-I-AM-AN-ORPHAN",
-    ]
-    assert stdout == expected
-
 
 def test_xunit_file_generation(tmp_path):  # tmp_path is a pytest fixture
     xunit_path = tmp_path / "xunit.xml"

--- a/tests/test_check_fixmes.py
+++ b/tests/test_check_fixmes.py
@@ -12,7 +12,7 @@ from . import base
 
 
 @mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
-def test_output_when_all_annotations_are_fresh(capfd):  # capfd is a pytest fixture
+def test_output_when_all_annotations_are_fresh(capfd: pytest.CaptureFixture):
     config = annotations.Config(
         path=base.TEST_DIR_PATH / "data/project1",
         max_age=9999,
@@ -39,7 +39,7 @@ def test_output_when_all_annotations_are_fresh(capfd):  # capfd is a pytest fixt
     assert stdout == expected
 
 
-def test_output_when_no_annotations(capfd):  # capfd is a pytest fixture
+def test_output_when_no_annotations(capfd: pytest.CaptureFixture):
     config = annotations.Config(path=base.TEST_DIR_PATH / "data/project2")
 
     with mock.patch("check_oldies.configuration.get_config", return_value=config):

--- a/tests/test_check_future_tags.py
+++ b/tests/test_check_future_tags.py
@@ -12,7 +12,7 @@ from . import base
 
 
 @mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
-def test_output_with_orphan_future_tags(capfd):  # capfd is a pytest fixture
+def test_output_with_orphan_future_tags(capfd: pytest.CaptureFixture):
     config = annotations.Config(
         path=base.TEST_DIR_PATH / "data/project3",
         colorize_errors=False,
@@ -35,7 +35,7 @@ def test_output_with_orphan_future_tags(capfd):  # capfd is a pytest fixture
 
 
 @mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
-def test_output_with_ignored_annotations_orphans_future_tags(capfd):  # capfd is a pytest fixture
+def test_output_with_ignored_annotations_orphans_future_tags(capfd: pytest.CaptureFixture):
     config = annotations.Config(
         path=base.TEST_DIR_PATH / "data/project6",
         colorize_errors=False,

--- a/tests/test_check_future_tags.py
+++ b/tests/test_check_future_tags.py
@@ -1,0 +1,58 @@
+"""Integration tests for the ``check-future-tags`` command."""
+
+import os
+from unittest import mock
+
+import pytest
+
+from check_oldies import annotations
+from check_oldies import check_future_tags
+
+from . import base
+
+
+@mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
+def test_output_with_orphan_future_tags(capfd):  # capfd is a pytest fixture
+    config = annotations.Config(
+        path=base.TEST_DIR_PATH / "data/project3",
+        colorize_errors=False,
+        annotations=base.TESTING_ANNOTATIONS,
+        future_tag_regex=base.TESTING_FUTURE_TAG,
+    )
+
+    with mock.patch("check_oldies.configuration.get_config", return_value=config):
+        with pytest.raises(SystemExit) as caught_exit:
+            check_future_tags.main()
+    captured = capfd.readouterr()
+
+    assert caught_exit.value.code == 65
+    stdout = captured.out.rstrip().split(os.linesep)
+    expected = [
+        "NOK: There are orphan FUTURE tags.",
+        "jane.doe        -   ORPHAN  - file2.py:2: Unknown tag FEWTURE-I-AM-AN-ORPHAN",
+    ]
+    assert stdout == expected
+
+
+@mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
+def test_output_with_ignored_annotations_orphans_future_tags(capfd):  # capfd is a pytest fixture
+    config = annotations.Config(
+        path=base.TEST_DIR_PATH / "data/project6",
+        colorize_errors=False,
+        annotations=base.TESTING_ANNOTATIONS,
+        ignored_orphans_annotations=base.TESTING_IGNORED_ORPHANS_ANNOTATIONS,
+        future_tag_regex=base.TESTING_FUTURE_TAG,
+    )
+
+    with mock.patch("check_oldies.configuration.get_config", return_value=config):
+        with pytest.raises(SystemExit) as caught_exit:
+            check_future_tags.main()
+    captured = capfd.readouterr()
+
+    assert caught_exit.value.code == 65
+    stdout = captured.out.rstrip().split(os.linesep)
+    expected = [
+        'NOK: There are orphan FUTURE tags.',
+        'jane.doe        -   ORPHAN  - file2.py:3: Unknown tag FEWTURE-I-AM-AN-ORPHAN'
+    ]
+    assert stdout == expected

--- a/tests/test_forget_me_not.py
+++ b/tests/test_forget_me_not.py
@@ -4,6 +4,8 @@ import contextlib
 import os
 from unittest import mock
 
+import pytest
+
 from check_oldies import forget_me_not
 
 from . import base
@@ -20,7 +22,7 @@ def in_working_directory(path):
 
 
 @mock.patch("check_oldies.annotations.get_line_blame", base.fake_get_line_blame)
-def test_forget_me_not(capfd):  # capfd is a pytest fixture
+def test_forget_me_not(capfd: pytest.CaptureFixture):
     with in_working_directory(base.TEST_DIR_PATH / 'data'):
         forget_me_not.main(argv=[])
     captured = capfd.readouterr()


### PR DESCRIPTION
The `check-fixmes` command used to report both FIXME and orphan FUTURE
flags. In the future, all commands will have a `--format` argument
that allows text, CSV or JSON output. Reporting FIXME's and FUTURE
tags in a single CSV file seems hard, because they don't have the same
attributes.

As such, `check-fixmes` now only reports FIXME's. A separate command
`check-future-flags` command reports FUTURE flags. One tool, one job.