### PR TITLE
build: Clean MANIFEST.in and fix release metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,11 +1,15 @@
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix project metadata and thus the build, which makes this version
+  1.0.1 installable (contrary to version 1.0.0).
 
 
 1.0.0 (2026-05-23)
 ------------------
+
+**Brown bag release:** this version could not be installed. See fix in
+version 1.0.1.
 
 - Add support of Python 3.12, 3.13 and 3.14.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,17 +1,14 @@
+graft src/check_oldies
+graft docs
+graft tests
+
 global-exclude *.py[cod]
 
 include CHANGES.rst
 include LICENSE.txt
 include README.rst
-
-graft src/check_oldies
-
-prune docs
-prune tests
-exclude .pylintrc
-exclude .readthedocs.yaml
-exclude Makefile
-exclude pyproject.toml
+include Makefile
 exclude RELEASE.txt
+exclude .readthedocs.yaml
 exclude requirements_dev.txt
 exclude stubs/toml/__init__.pyi


### PR DESCRIPTION
The file had useless entries, as can be seen when building:

    $ python -m build
    [...]
    no previously-included directories found matching 'docs'
    no previously-included directories found matching 'tests'
    warning: no previously-included files found matching '.pylintrc'
    warning: no previously-included files found matching '.readthedocs.yaml'
    warning: no previously-included files found matching 'Makefile'
    warning: no previously-included files found matching 'RELEASE.txt'
    warning: no previously-included files found matching 'requirements_dev.txt'
    warning: no previously-included files found matching 'stubs/toml/__init__.pyi'

Actually, excluding `pyproject.toml` like this caused an incorrect build, the version could not be found when building the wheel (but was seemingly correct for the sdist):

    $ python -m build
    [...]
    writing manifest file 'src/check_oldies.egg-info/SOURCES.txt'
    Copying src/check_oldies.egg-info to build/bdist.linux-x86_64/wheel/./check_oldies-0.0.0-py3.14.egg-info
    running install_scripts
    creating build/bdist.linux-x86_64/wheel/check_oldies-0.0.0.dist-info/WHEEL
    creating '/home/runner/work/check-oldies/check-oldies/dist/.tmp-wrut4psb/check_oldies-0.0.0-py3-none-any.whl' and adding 'build/bdist.linux-x86_64/wheel' to it
    [...]
    adding 'check_oldies-0.0.0.dist-info/licenses/LICENSE.txt'
    adding 'check_oldies-0.0.0.dist-info/METADATA'
    adding 'check_oldies-0.0.0.dist-info/WHEEL'
    adding 'check_oldies-0.0.0.dist-info/top_level.txt'
    adding 'check_oldies-0.0.0.dist-info/RECORD'
    removing build/bdist.linux-x86_64/wheel
    Successfully built check_oldies-1.0.0.tar.gz and check_oldies-0.0.0-py3-none-any.whl

Then, trying to install version 1.0.0 raised an error:

    $ pip install "check-oldies==1.0.0"
    Collecting check-oldies==1.0.0
      Using cached check_oldies-1.0.0.tar.gz (19 kB)
      Installing build dependencies ... done
      Getting requirements to build wheel ... done
      Preparing metadata (pyproject.toml) ... done
      WARNING: Requested check-oldies==1.0.0 from https://files.pythonhosted.org/packages/c8/00/cef7205cb647a28ff229bea9052d205aab054918d8d93d13ae418c629607/check_oldies-1.0.0.tar.gz, but installing version 0.0.0
    Discarding https://files.pythonhosted.org/packages/c8/00/cef7205cb647a28ff229bea9052d205aab054918d8d93d13ae418c629607/check_oldies-1.0.0.tar.gz (from https://pypi.org/simple/check-oldies/) (requires-python:>=3.10): Requested check-oldies==1.0.0 from https://files.pythonhosted.org/packages/c8/00/cef7205cb647a28ff229bea9052d205aab054918d8d93d13ae418c629607/check_oldies-1.0.0.tar.gz has inconsistent version: expected '1.0.0', but metadata has '0.0.0'
    ERROR: Could not find a version that satisfies the requirement check-oldies==1.0.0 (from versions: 0.0.0, 0.8.0, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 0.8.6, 0.8.7, 0.8.8, 0.8.9, 0.8.10, 1.0.0)

Fixes #26.